### PR TITLE
add: verification of item referencing for validated_by relationship

### DIFF
--- a/sphinxcontrib/traceability.py
+++ b/sphinxcontrib/traceability.py
@@ -119,6 +119,18 @@ class ItemDirective(Directive):
                 'Traceability: duplicated item %s' % targetid,
                 line=self.lineno)]
 
+        # Search for validated_by relationships in all ItemDirectives. If there
+        # are found some without a corresponding ItemDirective inform the user.
+        for targetid in env.traceability_all_items:
+            for rel in list(env.relationships.keys()):
+                if rel == 'validated_by':
+                    for referencedid in env.traceability_all_items[targetid][rel]:
+                        if referencedid not in env.traceability_all_items:
+                            print('missing item: {} (referenced by {} as validated_by'')'.format(referencedid, targetid))
+                            #messages = [self.state.document.reporter.error(
+                            #    'Traceability: missing referenced item %s' % referencedid,
+                            #    line=self.lineno)]
+
         return [targetnode] + messages
 
 

--- a/sphinxcontrib/traceability.py
+++ b/sphinxcontrib/traceability.py
@@ -121,15 +121,26 @@ class ItemDirective(Directive):
 
         # Search for validated_by relationships in all ItemDirectives. If there
         # are found some without a corresponding ItemDirective inform the user.
-        for targetid in env.traceability_all_items:
+        # (The dict 'items_referencing_missing_items' uses the referencing
+        # item as keys and a list of missing 'referenced_item' as value.
+        # Attention: referenced item is related to the relationship 'validated_by'
+        # only.)
+        items_referencing_missing_items = {}
+        for referencing_item in env.traceability_all_items:
             for rel in list(env.relationships.keys()):
                 if rel == 'validated_by':
-                    for referencedid in env.traceability_all_items[targetid][rel]:
-                        if referencedid not in env.traceability_all_items:
-                            print('missing item: {} (referenced by {} as validated_by'')'.format(referencedid, targetid))
-                            #messages = [self.state.document.reporter.error(
-                            #    'Traceability: missing referenced item %s' % referencedid,
-                            #    line=self.lineno)]
+                    for referenced_item in env.traceability_all_items[referencing_item][rel]:
+                        if referenced_item not in env.traceability_all_items:
+                            if referencing_item not in items_referencing_missing_items.keys():
+                                missing_referenced_items = []
+                                missing_referenced_items.append(referenced_item)
+                                items_referencing_missing_items[referencing_item] = missing_referenced_items
+                            else:
+                                missing_referenced_items = items_referencing_missing_items.get(referencing_item)
+                                missing_referenced_items.append(referenced_item)
+                                items_referencing_missing_items[referencing_item] = (missing_referenced_items)
+        if items_referencing_missing_items:
+            [print('missing item: {} (referenced by {} as validated_by)'.format(referenced_item, referencing_item)) for referencing_item, referenced_item in items_referencing_missing_items.items()]
 
         return [targetnode] + messages
 

--- a/tests/docs/autodoc/package/prod_code.py
+++ b/tests/docs/autodoc/package/prod_code.py
@@ -55,7 +55,7 @@ class Dog(Animal):
 
     .. item:: SW_REQ_005 A "dog" class shall implement the abstract animal interface.
         :implements: SW_REQ_001
-        :validated_by: SW_TEST_005
+        :validated_by: SW_TEST_005 SW_TEST_010
     """
 
     def talk(self):


### PR DESCRIPTION
I added some verification about items which reference other items with a validated_by relationship but which are not defined in the *.py or *.rst (or other files supported by sphinx). I added the reference to item SW_TEST_010 (which is not defined) in addition to item SW_TEST_005 (which is also not defined) in item SW_REQ_005 of the autodoc test. This makes obvious that the functionality does also work if more than one missing item is referenced with the same relationship. Basically the functionality does work.

The reason why this is a "support" request and no actual pull request:
As this feature is added in class ItemDirective which is called every time an item directive has been found the verification is executed several times before all items and item relationships are known. I assume the equivalent functionality should be implemented in function process_item_nodes() instead. But I am not sure how to implement it in process_item_nodes() (or somewhere else) and need some hint...

This draft issue can be observed on my fork when the sphinx-build is run over autodoc test (e.g. sphinx-build -b html . _build): The console output about missing referenced items is correct when in the autodoc test only prod_code.py has been changed. If test_code.py has been changed in addition to or without prod_code.py the console output shows some items which do actually have existing items (assumed root cause ~ functionality implemented in ItemDirective.run() instead of proess_item_nodes()).

Basically the logic could be used to check item referencing with all other relationship types as well. (The dict holding the "validated_by" referenced item id list as value would need a item id list for every relationship in this pull request implementation variant.)
